### PR TITLE
test: use typehint to prevent CI error (for PR #990)

### DIFF
--- a/tests/10.ABI.ts
+++ b/tests/10.ABI.ts
@@ -29,7 +29,7 @@ import { decodeAddress } from '../src/encoding/address';
 describe('ABI type checking', () => {
   it('should create the correct type from the string', () => {
     for (let i = 8; i < 513; i += 8) {
-      let expected = new ABIUintType(i);
+      let expected: ABIType = new ABIUintType(i);
       let actual = ABIType.from(`uint${i}`);
       assert.deepStrictEqual(actual, expected);
       for (let j = 1; j < 161; j++) {


### PR DESCRIPTION
Think it should fix the browser tests in
https://github.com/algorand/js-algorand-sdk/actions/runs/16733457099/job/47366838665?pr=990